### PR TITLE
Fix Consul service registration: health check needs a valid target

### DIFF
--- a/src/main/java/io/mapsmessaging/configuration/consul/ecwid/EcwidConsulManager.java
+++ b/src/main/java/io/mapsmessaging/configuration/consul/ecwid/EcwidConsulManager.java
@@ -118,7 +118,14 @@ public class EcwidConsulManager extends ConsulServerApi {
       return;
     }
     NewService.Check serviceCheck = new NewService.Check();
+    // A Consul check must specify a target. A bare interval with no TCP/HTTP/TTL
+    // target is rejected by the agent ("Invalid check: TTL must be > 0"), which made
+    // agentServiceRegister fail and left the mapsMessaging service absent from the
+    // catalog. Use a TCP check against the service port so registration succeeds and
+    // the service is health-checked.
+    serviceCheck.setTcp("localhost:" + Constants.CONSUL_PORT);
     serviceCheck.setInterval("10s");
+    serviceCheck.setDeregisterCriticalServiceAfter("1m");
 
     List<String> propertyNames = new ArrayList<>();
     logger.log(CONSUL_REGISTER);


### PR DESCRIPTION
## Summary

`EcwidConsulManager.register()` built the service health `Check` with only `setInterval("10s")` and **no target** (no TCP/HTTP/TTL). The Consul agent rejects such a check — `agentServiceRegister` fails with `400 Bad Request: Invalid check: TTL must be > 0 for TTL checks` — so the `mapsMessaging` service never lands in the Consul **catalog** (`/v1/catalog/services` shows only `consul`). KV config + agent membership were unaffected, so this failed silently.

The companion `pingService()` is an empty `// To Do`, so the intended TTL-ping design was never completed.

## Change
Give the check a valid target — a TCP check against the service port (`Constants.CONSUL_PORT`, the MAPS REST port) — plus a `DeregisterCriticalServiceAfter` so stale entries clean up:

```java
serviceCheck.setTcp("localhost:" + Constants.CONSUL_PORT);
serviceCheck.setInterval("10s");
serviceCheck.setDeregisterCriticalServiceAfter("1m");
```

A TCP check needs no health-endpoint path and doesn't depend on the unfinished ping loop; registration now succeeds and the service is actively health-checked. (If you'd prefer an HTTP check against a REST health endpoint, or to finish the TTL+`pingService()` approach instead, happy to adjust.)

## How it was found
Running a Consul client agent inside the MAPS containers (for the tailnet-onboarding stack): MAPS joined Consul and auto-seeded its KV config fine, but `/v1/catalog/services` never showed `mapsMessaging`. Traced to this check being rejected by the agent.

## Test Plan
- [ ] CI builds (local full build here was blocked by an unrelated dependency-chain setup, not this change; `NewService.Check.setTcp/​setDeregisterCriticalServiceAfter` are confirmed present in the ecwid `consul-api` 1.4.5 client).
- [ ] With a MAPS instance pointed at a Consul agent, `curl /v1/catalog/services` now lists `mapsMessaging`, and the service check is present/passing while the REST port is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)