### PR TITLE
Track source paths for file-backed configurations

### DIFF
--- a/src/main/java/io/mapsmessaging/configuration/ConfigurationProperties.java
+++ b/src/main/java/io/mapsmessaging/configuration/ConfigurationProperties.java
@@ -43,6 +43,9 @@ public class ConfigurationProperties {
   @Getter
   @Setter
   private String source;
+  @Getter
+  @Setter
+  private String sourcePath;
   @Setter
   private ConfigurationProperties global;
 

--- a/src/main/java/io/mapsmessaging/configuration/PropertyManager.java
+++ b/src/main/java/io/mapsmessaging/configuration/PropertyManager.java
@@ -50,9 +50,20 @@ public abstract class PropertyManager {
 
   public abstract void copy(PropertyManager propertyManager) throws IOException;
 
-  public void update(String path, String name, ConfigurationProperties newProps) throws IOException{
+  public void update(String path, String name, ConfigurationProperties newProps) throws IOException {
+    Object current = properties.get(name);
+    if (!(current instanceof ConfigurationProperties currentProps)) {
+      throw new IllegalArgumentException("Unknown configuration: " + name);
+    }
+
+    newProps.setSourcePath(currentProps.getSourcePath());
     properties.replace(name, newProps);
-    store(path, name);
+    try {
+      store(path, name);
+    } catch (IOException | RuntimeException e) {
+      properties.replace(name, currentProps);
+      throw e;
+    }
   }
 
   protected abstract List<String> getKeys(String lookup);

--- a/src/main/java/io/mapsmessaging/configuration/file/FileYamlPropertyManager.java
+++ b/src/main/java/io/mapsmessaging/configuration/file/FileYamlPropertyManager.java
@@ -26,6 +26,8 @@ import io.mapsmessaging.logging.LoggerFactory;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -40,7 +42,7 @@ public class FileYamlPropertyManager extends YamlPropertyManager {
   @Override
   public void load() {
     try {
-      Collection<String> knownProperties = ResourceList.getResources(Pattern.compile(".*yaml"));
+      Collection<String> knownProperties = ResourceList.getResources(Pattern.compile(".*\\.yaml$"));
       for (String propertyName : knownProperties) {
         try {
           loadProperty(propertyName);
@@ -60,37 +62,40 @@ public class FileYamlPropertyManager extends YamlPropertyManager {
     return new ArrayList<>();
   }
 
-  private void loadProperty(String propertyName) {
+  private void loadProperty(String resourceName) {
+    String propertyName = resourceName;
     try {
-      propertyName = propertyName.substring(propertyName.lastIndexOf(File.separatorChar) + 1);
+      int separator = Math.max(propertyName.lastIndexOf('/'), propertyName.lastIndexOf('\\'));
+      propertyName = propertyName.substring(separator + 1);
       propertyName = propertyName.substring(0, propertyName.indexOf(".yaml"));
-      loadFile(propertyName);
+      Path sourcePath = Path.of(resourceName);
+      if (Files.isRegularFile(sourcePath)) {
+        loadFile(propertyName, sourcePath);
+      } else {
+        loadResource(propertyName);
+      }
       logger.log(PROPERTY_MANAGER_FOUND, propertyName);
     } catch (IOException e) {
       logger.log(PROPERTY_MANAGER_LOAD_FAILED, e, propertyName);
     }
   }
 
-  private void loadFile(String propertyName) throws IOException {
+  private void loadFile(String propertyName, Path sourcePath) throws IOException {
+    Path canonicalPath = sourcePath.toRealPath();
+    parseAndLoadYaml(propertyName, Files.readString(canonicalPath, StandardCharsets.UTF_8), canonicalPath.toString());
+  }
+
+  private void loadResource(String propertyName) throws IOException {
     String propResourceName = "/" + propertyName;
     while (propResourceName.contains(".")) {
       propResourceName = propResourceName.replace('.', File.separatorChar);
     }
     propResourceName = propResourceName + ".yaml";
-    InputStream is = getClass().getResourceAsStream(propResourceName);
-    if (is != null) {
-      int read = 1;
-      byte[] buffer = new byte[1024];
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      while (read > 0) {
-        read = is.read(buffer);
-        if (read > 0) {
-          byteArrayOutputStream.write(buffer, 0, read);
-        }
+    try (InputStream inputStream = getClass().getResourceAsStream(propResourceName)) {
+      if (inputStream != null) {
+        parseAndLoadYaml(propertyName, new String(inputStream.readAllBytes(), StandardCharsets.UTF_8));
+        return;
       }
-      is.close();
-      parseAndLoadYaml(propertyName, byteArrayOutputStream.toString(StandardCharsets.UTF_8));
-    } else {
       throw new FileNotFoundException("No such resource found " + propResourceName);
     }
   }

--- a/src/main/java/io/mapsmessaging/configuration/yaml/YamlPropertyManager.java
+++ b/src/main/java/io/mapsmessaging/configuration/yaml/YamlPropertyManager.java
@@ -27,9 +27,11 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -42,6 +44,10 @@ public abstract class YamlPropertyManager extends PropertyManager {
   private static final String GLOBAL = "global";
 
   protected void parseAndLoadYaml(String propertyName, String yamlString) {
+    parseAndLoadYaml(propertyName, yamlString, null);
+  }
+
+  protected void parseAndLoadYaml(String propertyName, String yamlString, String sourcePath) {
     Yaml yaml = new Yaml();
     JsonParser parser = new YamlParser(yaml.load(yamlString));
     Map<String, Object> response = parser.parse();
@@ -60,6 +66,7 @@ public abstract class YamlPropertyManager extends PropertyManager {
       configurationProperties.putAll(entry);
     }
     configurationProperties.setSource(yamlString);
+    configurationProperties.setSourcePath(sourcePath);
     properties.put(propertyName, configurationProperties);
   }
 
@@ -89,10 +96,16 @@ public abstract class YamlPropertyManager extends PropertyManager {
     options.setIndent(3); // Custom indentation level for better formatting
 
 
-    try (PrintWriter writer = new PrintWriter(path+ File.separator+key+".yaml")) {
+    Path target = configurationProperties.getSourcePath() == null || configurationProperties.getSourcePath().isBlank()
+        ? Path.of(path, key + ".yaml")
+        : Path.of(configurationProperties.getSourcePath());
+    try (PrintWriter writer = new PrintWriter(Files.newBufferedWriter(target, StandardCharsets.UTF_8))) {
       addHeader(writer);
       Yaml yaml = new Yaml(options);
       yaml.dump(data, writer);
+      if (writer.checkError()) {
+        throw new IOException("Failed to write configuration: " + target);
+      }
     }
 
   }

--- a/src/test/java/io/mapsmessaging/configuration/ConfigurationPropertiesTest.java
+++ b/src/test/java/io/mapsmessaging/configuration/ConfigurationPropertiesTest.java
@@ -43,6 +43,8 @@ class ConfigurationPropertiesTest {
     properties.put("stringList", stringList);
     properties.setSource(properties.toString());
     Assertions.assertEquals(properties.toString(), properties.getSource());
+    properties.setSourcePath("/tmp/test.yaml");
+    Assertions.assertEquals("/tmp/test.yaml", properties.getSourcePath());
 
     Assertions.assertFalse(properties.isEmpty());
     Assertions.assertNotNull(properties.getProperty("stringList"));

--- a/src/test/java/io/mapsmessaging/configuration/PropertyManagerTest.java
+++ b/src/test/java/io/mapsmessaging/configuration/PropertyManagerTest.java
@@ -21,17 +21,22 @@ package io.mapsmessaging.configuration;
 
 import com.google.gson.JsonObject;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.List;;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class PropertyManagerTest {
+
+  @TempDir
+  protected Path tempDirectory;
 
   protected abstract PropertyManager create();
 
@@ -49,31 +54,27 @@ public abstract class PropertyManagerTest {
     assertTrue(manager.properties.isEmpty());
     manager.load();
     assertFalse(manager.properties.isEmpty());
-    File outFile = new File("./configTestFile");
-    if(outFile.exists()){
-      outFile.delete();
-    }
-    manager.storeAll(outFile.getAbsolutePath());
-    assertTrue(outFile.exists());
-    assertTrue(outFile.delete());
+    Path outFile = tempDirectory.resolve("configTestFile");
+    manager.storeAll(outFile.toString());
+    assertTrue(Files.exists(outFile));
   }
 
   @Test
   void store() throws IOException {
     PropertyManager manager = create();
-    assertTrue(manager.properties.isEmpty());
-    manager.load();
-    assertFalse(manager.properties.isEmpty());
-    File outFile = new File("./test1.yaml");
-    if(outFile.exists()){
-      outFile.delete();
-    }
-    ConfigurationProperties prop = manager.getProperties("test1");
-    prop.put("Updatedkey", "updated value");
-    manager.update(".", "test1", prop);
-    manager.storeAll(outFile.getAbsolutePath());
-    assertTrue(outFile.exists());
-    assertTrue(outFile.delete());
+    ConfigurationProperties existing = new ConfigurationProperties();
+    manager.properties.put("generated", existing);
+
+    ConfigurationProperties updated = new ConfigurationProperties();
+    updated.put("Updatedkey", "updated value");
+    ConfigurationProperties document = new ConfigurationProperties();
+    document.put("generated", updated);
+
+    manager.update(tempDirectory.toString(), "generated", document);
+
+    Path outFile = tempDirectory.resolve("generated.yaml");
+    assertTrue(Files.exists(outFile));
+    assertTrue(Files.readString(outFile).contains("Updatedkey: updated value"));
   }
 
 

--- a/src/test/java/io/mapsmessaging/configuration/file/FilePropertyManagerTest.java
+++ b/src/test/java/io/mapsmessaging/configuration/file/FilePropertyManagerTest.java
@@ -26,6 +26,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 
 class FilePropertyManagerTest extends PropertyManagerTest {
 
@@ -58,6 +69,88 @@ class FilePropertyManagerTest extends PropertyManagerTest {
       }
     }
     Assertions.assertTrue(found, "Log message should have been raised");
+  }
+
+  @Test
+  void recordsSourcePathAndUpdatesOriginalFile() throws IOException {
+    Path source = writeConfiguration("source-path", "original");
+    Path redirected = tempDirectory.resolve("redirected.yaml");
+    FileYamlPropertyManager manager = loadFrom(tempDirectory);
+
+    ConfigurationProperties loaded = manager.getProperties("source-path");
+    assertEquals(source.toRealPath().toString(), loaded.getSourcePath());
+
+    ConfigurationProperties replacement = createDocument("source-path", "updated");
+    replacement.setSourcePath(redirected.toString());
+    manager.update(tempDirectory.resolve("fallback").toString(), "source-path", replacement);
+
+    assertEquals(source.toRealPath().toString(), replacement.getSourcePath());
+    assertTrue(Files.readString(source, StandardCharsets.UTF_8).contains("value: updated"));
+    assertFalse(Files.exists(redirected));
+    assertFalse(Files.exists(tempDirectory.resolve("fallback/source-path.yaml")));
+  }
+
+  @Test
+  void rejectsUnknownConfiguration() {
+    FileYamlPropertyManager manager = new FileYamlPropertyManager();
+
+    IllegalArgumentException exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> manager.update(tempDirectory.toString(), "missing", createDocument("missing", "updated")));
+
+    assertEquals("Unknown configuration: missing", exception.getMessage());
+    assertFalse(Files.exists(tempDirectory.resolve("missing.yaml")));
+  }
+
+  @Test
+  void restoresInMemoryConfigurationWhenStoreFails() throws IOException {
+    Path source = writeConfiguration("rollback", "original");
+    FileYamlPropertyManager manager = loadFrom(tempDirectory);
+    ConfigurationProperties original = manager.getProperties("rollback");
+
+    Files.delete(source);
+    Files.createDirectory(source);
+
+    assertThrows(IOException.class, () -> manager.update(tempDirectory.toString(), "rollback", createDocument("rollback", "updated")));
+    assertSame(original, manager.getProperties("rollback"));
+    assertEquals("original", original.getProperty("value"));
+  }
+
+  @Test
+  void skipsMalformedYamlAndNonYamlFiles() throws IOException {
+    Files.writeString(tempDirectory.resolve("malformed.yaml"), "malformed: [", StandardCharsets.UTF_8);
+    Files.writeString(tempDirectory.resolve("ignored.yaml.bak"), "ignored:\n   value: ignored\n", StandardCharsets.UTF_8);
+
+    FileYamlPropertyManager manager = loadFrom(tempDirectory);
+
+    assertFalse(manager.contains("malformed"));
+    assertFalse(manager.contains("ignored"));
+  }
+
+  private FileYamlPropertyManager loadFrom(Path directory) {
+    String originalClassPath = System.getProperty("java.class.path");
+    FileYamlPropertyManager manager = new FileYamlPropertyManager();
+    try {
+      System.setProperty("java.class.path", directory.toString());
+      manager.load();
+    } finally {
+      System.setProperty("java.class.path", originalClassPath);
+    }
+    return manager;
+  }
+
+  private Path writeConfiguration(String name, String value) throws IOException {
+    Path path = tempDirectory.resolve(name + ".yaml");
+    Files.writeString(path, name + ":\n   value: " + value + "\n", StandardCharsets.UTF_8);
+    return path;
+  }
+
+  private ConfigurationProperties createDocument(String name, String value) {
+    ConfigurationProperties values = new ConfigurationProperties();
+    values.put("value", value);
+    ConfigurationProperties document = new ConfigurationProperties();
+    document.put(name, values);
+    return document;
   }
 
 }


### PR DESCRIPTION
## What changed

- record the canonical source path when a YAML configuration is loaded from a file
- preserve that path when replacing a configuration
- write updates back to the original source file
- retain the existing directory-and-key fallback for configurations without a file origin
- reject updates to unknown configurations
- restore the previous in-memory configuration when persistence fails
- restrict discovery to files ending in `.yaml`

## Why

The server currently calls the configuration library with a generic `./conf` path during updates. That can write a configuration to a different file from the one that originally supplied it. Retaining the source path lets the library update the correct file without requiring the caller to reconstruct its location.

## Tests

Added coverage for:

- recording and using the original source path
- preventing caller-supplied path redirection
- the legacy fallback path
- unknown configuration names
- rollback after a failed write
- malformed YAML
- ignoring files such as `.yaml.bak`

`git diff --check` passes.

The Maven test suite could not be executed in the available runner because Maven Central is unavailable and the runner has no dependency cache.