### PR TITLE
Register the MapsMessaging REST endpoint with Consul

### DIFF
--- a/src/main/java/io/mapsmessaging/configuration/consul/Constants.java
+++ b/src/main/java/io/mapsmessaging/configuration/consul/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
   public static final long HEALTH_TIME = 40;
   public static final int CONSUL_PORT = 8080;
   public static final String NAME = "mapsMessaging";
+  public static final String REST_API = "rest";
   public static final int RETRY_COUNT = 20;
 
   private Constants() {

--- a/src/main/java/io/mapsmessaging/configuration/consul/ConsulServerApi.java
+++ b/src/main/java/io/mapsmessaging/configuration/consul/ConsulServerApi.java
@@ -23,6 +23,9 @@ import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.utilities.threads.SimpleTaskScheduler;
 
 import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -95,6 +98,35 @@ public abstract class ConsulServerApi implements Runnable {
 
   public String getUrlPath() {
     return consulConfiguration.getUrlPath();
+  }
+
+  public InetAddress getLocalAddress() throws IOException {
+    return resolveLocalAddress(consulConfiguration.getConsulUrl());
+  }
+
+  static InetAddress resolveLocalAddress(String consulUrl) throws IOException {
+    URI consulUri;
+    try {
+      consulUri = URI.create(consulUrl);
+    } catch (IllegalArgumentException e) {
+      throw new IOException("Invalid Consul URL: " + consulUrl, e);
+    }
+    String consulHost = consulUri.getHost();
+    if (consulHost == null || consulHost.isBlank()) {
+      throw new IOException("Consul URL does not contain a host: " + consulUrl);
+    }
+    int consulPort = consulUri.getPort();
+    if (consulPort < 0) {
+      consulPort = "https".equalsIgnoreCase(consulUri.getScheme()) ? 443 : 8500;
+    }
+    try (DatagramSocket socket = new DatagramSocket()) {
+      socket.connect(InetAddress.getByName(consulHost), consulPort);
+      InetAddress localAddress = socket.getLocalAddress();
+      if (localAddress.isAnyLocalAddress()) {
+        throw new IOException("Unable to determine the local address used to reach Consul: " + consulUrl);
+      }
+      return localAddress;
+    }
   }
 
   public abstract List<String> getKeys(String key) throws IOException;

--- a/src/main/java/io/mapsmessaging/configuration/consul/ecwid/EcwidConsulManager.java
+++ b/src/main/java/io/mapsmessaging/configuration/consul/ecwid/EcwidConsulManager.java
@@ -36,8 +36,11 @@ import org.apache.http.message.BasicHeader;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -117,26 +120,51 @@ public class EcwidConsulManager extends ConsulServerApi {
     if (!consulConfiguration.registerAgent()) {
       return;
     }
+    NewService newService = createService(uniqueName, meta);
+    logger.log(CONSUL_REGISTER);
+    client.agentServiceRegister(newService);
+    registerPingTask();
+  }
+
+  static NewService createService(String uniqueName, Map<String, String> meta) {
+    String restEndpoint = meta == null ? null : meta.get(Constants.REST_API);
+    if (restEndpoint == null || restEndpoint.isBlank()) {
+      throw new IllegalArgumentException("REST API endpoint is required for Consul registration");
+    }
+
+    URI endpoint;
+    try {
+      endpoint = new URI("tcp://" + restEndpoint);
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Invalid REST API endpoint: " + restEndpoint, e);
+    }
+
+    String host = endpoint.getHost();
+    int port = endpoint.getPort();
+    if (host != null && host.startsWith("[") && host.endsWith("]")) {
+      host = host.substring(1, host.length() - 1);
+    }
+    if (host == null || host.isBlank() || port < 1 || port > 65535) {
+      throw new IllegalArgumentException("Invalid REST API endpoint: " + restEndpoint);
+    }
+    if (host.equals("0.0.0.0") || host.equals("::") || host.equals("0:0:0:0:0:0:0:0")) {
+      throw new IllegalArgumentException("REST API endpoint must not use a wildcard address: " + restEndpoint);
+    }
+
+    String tcpEndpoint = host.contains(":") ? "[" + host + "]:" + port : host + ":" + port;
     NewService.Check serviceCheck = new NewService.Check();
-    // A Consul check must specify a target. A bare interval with no TCP/HTTP/TTL
-    // target is rejected by the agent ("Invalid check: TTL must be > 0"), which made
-    // agentServiceRegister fail and left the mapsMessaging service absent from the
-    // catalog. Use a TCP check against the service port so registration succeeds and
-    // the service is health-checked.
-    serviceCheck.setTcp("localhost:" + Constants.CONSUL_PORT);
+    serviceCheck.setTcp(tcpEndpoint);
     serviceCheck.setInterval("10s");
     serviceCheck.setDeregisterCriticalServiceAfter("1m");
 
-    List<String> propertyNames = new ArrayList<>();
-    logger.log(CONSUL_REGISTER);
     NewService newService = new NewService();
     newService.setId(uniqueName);
     newService.setName(Constants.NAME);
-    newService.setTags(propertyNames);
-    newService.setPort(Constants.CONSUL_PORT);
+    newService.setAddress(host);
+    newService.setPort(port);
+    newService.setMeta(new LinkedHashMap<>(meta));
     newService.setCheck(serviceCheck);
-    client.agentServiceRegister(newService);
-    registerPingTask();
+    return newService;
   }
 
   private void recreateClient() throws IOException {

--- a/src/test/java/io/mapsmessaging/configuration/consul/ConsulServerApiTest.java
+++ b/src/test/java/io/mapsmessaging/configuration/consul/ConsulServerApiTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.mapsmessaging.configuration.consul;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ConsulServerApiTest {
+
+  @Test
+  void resolveLocalAddress_usesRouteToConsulHost() throws IOException {
+    InetAddress address = ConsulServerApi.resolveLocalAddress("http://127.0.0.1:8500");
+
+    assertEquals("127.0.0.1", address.getHostAddress());
+  }
+
+  @Test
+  void resolveLocalAddress_rejectsUrlWithoutHost() {
+    assertThrows(IOException.class, () -> ConsulServerApi.resolveLocalAddress("not-a-consul-url"));
+  }
+}

--- a/src/test/java/io/mapsmessaging/configuration/consul/ecwid/EcwidConsulManagerTest.java
+++ b/src/test/java/io/mapsmessaging/configuration/consul/ecwid/EcwidConsulManagerTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright [ 2020 - 2024 ] Matthew Buckton
+ *  Copyright [ 2024 - 2026 ] MapsMessaging B.V.
+ *
+ *  Licensed under the Apache License, Version 2.0 with the Commons Clause
+ *  (the "License"); you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://commonsclause.com/
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.mapsmessaging.configuration.consul.ecwid;
+
+import com.ecwid.consul.v1.agent.model.NewService;
+import io.mapsmessaging.configuration.consul.Constants;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EcwidConsulManagerTest {
+
+  @Test
+  void createService_usesRestEndpointForRegistrationAndHealthCheck() {
+    Map<String, String> meta = new LinkedHashMap<>();
+    meta.put("mqtt", "tcp://0.0.0.0:1883/");
+    meta.put(Constants.REST_API, "192.0.2.10:8081");
+
+    NewService service = EcwidConsulManager.createService("server-1", meta);
+
+    assertEquals("server-1", service.getId());
+    assertEquals(Constants.NAME, service.getName());
+    assertEquals("192.0.2.10", service.getAddress());
+    assertEquals(8081, service.getPort());
+    assertEquals(meta, service.getMeta());
+    assertEquals("192.0.2.10:8081", service.getCheck().getTcp());
+  }
+
+  @Test
+  void createService_supportsIpv6RestEndpoint() {
+    Map<String, String> meta = Map.of(Constants.REST_API, "[2001:db8::10]:8443");
+
+    NewService service = EcwidConsulManager.createService("server-1", meta);
+
+    assertEquals("2001:db8::10", service.getAddress());
+    assertEquals(8443, service.getPort());
+    assertEquals("[2001:db8::10]:8443", service.getCheck().getTcp());
+  }
+
+  @Test
+  void createService_rejectsMissingRestEndpoint() {
+    assertThrows(IllegalArgumentException.class, () -> EcwidConsulManager.createService("server-1", Map.of()));
+    assertThrows(IllegalArgumentException.class, () -> EcwidConsulManager.createService("server-1", null));
+  }
+
+  @Test
+  void createService_rejectsMalformedRestEndpoint() {
+    assertThrows(IllegalArgumentException.class, () -> EcwidConsulManager.createService("server-1", Map.of(Constants.REST_API, "192.0.2.10")));
+    assertThrows(IllegalArgumentException.class, () -> EcwidConsulManager.createService("server-1", Map.of(Constants.REST_API, "192.0.2.10:not-a-port")));
+  }
+
+  @Test
+  void createService_rejectsWildcardRestEndpoint() {
+    assertThrows(IllegalArgumentException.class, () -> EcwidConsulManager.createService("server-1", Map.of(Constants.REST_API, "0.0.0.0:8080")));
+    assertThrows(IllegalArgumentException.class, () -> EcwidConsulManager.createService("server-1", Map.of(Constants.REST_API, "[::]:8080")));
+  }
+}


### PR DESCRIPTION
## What changed

- read the `rest` endpoint from service metadata
- register its address and port as the MapsMessaging Consul service
- preserve the full messaging endpoint map as Consul service metadata
- run the TCP health check against the advertised REST endpoint
- determine the advertised local address using the OS route to the configured Consul host
- reject missing, malformed, or wildcard REST endpoints
- support IPv4 and IPv6 endpoints

## Why

The existing registration advertises a hard-coded port and asks the Consul agent to check `localhost`. That checks the Consul agent's host rather than the MapsMessaging server when Consul is remote.

Route-based address selection also avoids advertising an unrelated interface on multi-homed systems.

## Companion change

MapsMessaging server PR: https://github.com/Maps-Messaging/mapsmessaging_server/pull/2170

## Validation

Added focused tests covering IPv4, IPv6, missing endpoints, malformed endpoints, wildcard addresses, route-based local-address selection, and invalid Consul URLs. `git diff --check` passes.

The Maven test could not run in the available environment because Maven Central is not reachable and no dependency cache is available.